### PR TITLE
Pin ipywidgets<8

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -3,6 +3,8 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.8
-  - kissim
+  # https://github.com/volkamerlab/kissim/issues/112
+  - ipywidgets<8
   - jupyter
   - jupyterlab>=3
+  - kissim


### PR DESCRIPTION
Pin `ipywidgets` to versions <8, which fixes problems with `nglview` and therefore its usage in `kissim`, see discussion here: https://github.com/nglviewer/nglview/issues/1032

This should fix https://github.com/volkamerlab/cicag_klifs_workshop/issues/2